### PR TITLE
Fix local verbose logging

### DIFF
--- a/EPNMonitoring/FileLoggerProvider.cs
+++ b/EPNMonitoring/FileLoggerProvider.cs
@@ -1,0 +1,72 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Logging;
+
+namespace EPNMonitoring
+{
+    /// <summary>
+    /// Simple logger provider that writes log messages to a single file.
+    /// </summary>
+    public sealed class FileLoggerProvider : ILoggerProvider
+    {
+        private readonly string _filePath;
+        private readonly object _lock = new();
+        private readonly StreamWriter _writer;
+
+        public FileLoggerProvider(string filePath)
+        {
+            _filePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+            var dir = Path.GetDirectoryName(_filePath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+            _writer = new StreamWriter(File.Open(_filePath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))
+            {
+                AutoFlush = true
+            };
+        }
+
+        public ILogger CreateLogger(string categoryName) => new FileLogger(_writer, _lock, categoryName);
+
+        public void Dispose() => _writer.Dispose();
+
+        private sealed class FileLogger : ILogger
+        {
+            private readonly StreamWriter _writer;
+            private readonly object _lock;
+            private readonly string _categoryName;
+
+            public FileLogger(StreamWriter writer, object lockObj, string categoryName)
+            {
+                _writer = writer;
+                _lock = lockObj;
+                _categoryName = categoryName;
+            }
+
+            public IDisposable BeginScope<TState>(TState state) => null!;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (formatter == null) throw new ArgumentNullException(nameof(formatter));
+
+                var message = formatter(state, exception);
+                if (string.IsNullOrEmpty(message) && exception == null) return;
+
+                var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+                var line = $"{timestamp} [{logLevel}] {_categoryName}: {message}";
+                if (exception != null)
+                {
+                    line += $" {exception}";
+                }
+
+                lock (_lock)
+                {
+                    _writer.WriteLine(line);
+                }
+            }
+        }
+    }
+}

--- a/EPNMonitoring/Program.cs
+++ b/EPNMonitoring/Program.cs
@@ -1,7 +1,15 @@
 using EPNMonitoring;
 using Microsoft.Extensions.Hosting.WindowsServices;
+using Microsoft.Extensions.Logging;
 
 var builder = Host.CreateApplicationBuilder(args);
+
+// Configure optional local file logging based on configuration
+var localLogPath = builder.Configuration.GetValue<string>("LocalLog:FilePath");
+if (!string.IsNullOrWhiteSpace(localLogPath))
+{
+    builder.Logging.AddProvider(new FileLoggerProvider(localLogPath));
+}
 
 
 // Enable running as a Windows service so the application can properly


### PR DESCRIPTION
## Summary
- add a simple `FileLoggerProvider` to write logs to disk
- wire up the provider in `Program.cs` using the `LocalLog:FilePath` setting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848374bd1708333aaeea4ae65b64a7c