### PR TITLE
Add event viewer monitoring

### DIFF
--- a/EPNMonitoring/appsettings.json
+++ b/EPNMonitoring/appsettings.json
@@ -56,6 +56,12 @@
       "https://www.github.com"
     ]
   },
+  "EventViewerMonitor": {
+    "CheckIntervalSeconds": 60,
+    "Applications": [
+      "notepad.exe"
+    ]
+  },
   "VerboseLogging": {
     "AppInsight": false,
     "Local": false


### PR DESCRIPTION
## Summary
- monitor Application Error events in Windows event log
- configure EventViewerMonitor interval and applications in appsettings

## Testing
- `dotnet build EPNMonitoring/EPNMonitoring.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540c4881e88333aa94bafd9ab3155d