### PR TITLE
Add printer monitor for physical devices

### DIFF
--- a/EPNMonitoring/Worker.cs
+++ b/EPNMonitoring/Worker.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices;
 
 namespace EPNMonitoring
 {
@@ -89,6 +90,9 @@ namespace EPNMonitoring
 
         // Local log settings
         private readonly int _localLogCheckIntervalSeconds;
+
+        [DllImport("winspool.drv", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool SetDefaultPrinter(string name);
 
         public Worker(
             ILogger<Worker> logger,
@@ -520,15 +524,10 @@ namespace EPNMonitoring
 
                         if (_removeOfflinePrinters)
                         {
-                            try
-                            {
-                                printer.Delete();
+                            if (TryRemovePrinter(printer, name))
                                 _logger.LogInformation("Removed offline printer: {Name}", name);
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.LogError(ex, "Failed to remove printer: {Name}", name);
-                            }
+                            else
+                                _logger.LogWarning("Unable to remove offline printer: {Name}", name);
                         }
                     }
                 }
@@ -545,9 +544,17 @@ namespace EPNMonitoring
                 {
                     try
                     {
-                        onlinePrinter.InvokeMethod("SetDefaultPrinter", null);
-                        if (_verboseLoggingLocal)
-                            _logger.LogInformation("Set default printer to {Name}", onlinePrinter["Name"]);
+                        string? printerName = onlinePrinter["Name"]?.ToString();
+                        if (!string.IsNullOrEmpty(printerName) && SetDefaultPrinter(printerName))
+                        {
+                            if (_verboseLoggingLocal)
+                                _logger.LogInformation("Set default printer to {Name}", printerName);
+                        }
+                        else
+                        {
+                            int error = Marshal.GetLastWin32Error();
+                            _logger.LogError("Failed to set default printer: {Name} (Error={Error})", printerName, error);
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -559,6 +566,41 @@ namespace EPNMonitoring
             {
                 _logger.LogError(ex, "Printer check failed.");
             }
+        }
+
+        private bool TryRemovePrinter(ManagementObject printer, string name)
+        {
+            bool removed = false;
+            try
+            {
+                var result = printer.InvokeMethod("Delete", null);
+                removed = result == null || Convert.ToUInt32(result) == 0;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "WMI delete failed for printer {Name}", name);
+            }
+
+            if (!removed)
+            {
+                try
+                {
+                    var psi = new ProcessStartInfo("rundll32.exe", $"printui.dll,PrintUIEntry /dn /n \"{name}\"")
+                    {
+                        CreateNoWindow = true,
+                        UseShellExecute = false
+                    };
+                    using var proc = Process.Start(psi);
+                    proc?.WaitForExit();
+                    removed = proc?.ExitCode == 0;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to remove printer via PrintUIEntry: {Name}", name);
+                }
+            }
+
+            return removed;
         }
 
         /// <summary>

--- a/EPNMonitoring/Worker.cs
+++ b/EPNMonitoring/Worker.cs
@@ -49,6 +49,12 @@ namespace EPNMonitoring
         private readonly List<string> _devicesToCheck;
         private readonly int _deviceCheckIntervalSeconds;
 
+        // Printer monitor
+        private readonly string _printerNameWildcard;
+        private readonly int _printerCheckIntervalSeconds;
+        private readonly bool _removeOfflinePrinters;
+        private readonly bool _setDefaultPrinter;
+
         // Port tests monitor
         private readonly string _portTestServer;
         private readonly List<PortTestServerConfig> _portTestServers;
@@ -78,6 +84,7 @@ namespace EPNMonitoring
         private readonly bool _eventViewerMonitorEnabled;
         private readonly bool _deviceMonitorEnabled;
         private readonly bool _portTestsMonitorEnabled;
+        private readonly bool _printerMonitorEnabled;
         private readonly bool _kioskUserEnabled;
 
         // Local log settings
@@ -119,6 +126,13 @@ namespace EPNMonitoring
             _devicesToCheck = _configuration.GetSection("DeviceMonitor:Devices").Get<List<string>>() ?? new List<string>();
             _deviceCheckIntervalSeconds = _configuration.GetValue<int>("DeviceMonitor:CheckIntervalSeconds", 60);
 
+            // Printer monitor config
+            var printerSection = _configuration.GetSection("PrinterMonitor");
+            _printerNameWildcard = printerSection.GetValue<string>("PrinterNameWildcard", "Brother HL");
+            _printerCheckIntervalSeconds = printerSection.GetValue<int>("CheckIntervalSeconds", 300);
+            _removeOfflinePrinters = printerSection.GetValue<bool>("RemoveOfflinePrinters", false);
+            _setDefaultPrinter = printerSection.GetValue<bool>("SetAsDefaultPrinter", false);
+
             // Port tests monitor config
             var portTestsMonitorSection = _configuration.GetSection("PortTestsMonitor");
             _portTestServers = portTestsMonitorSection.GetSection("Servers").Get<List<PortTestServerConfig>>() ?? new List<PortTestServerConfig>();
@@ -159,6 +173,7 @@ namespace EPNMonitoring
             _eventViewerMonitorEnabled = _configuration.GetValue<bool>("EventViewerMonitor:Enabled", true);
             _deviceMonitorEnabled = _configuration.GetValue<bool>("DeviceMonitor:Enabled", true);
             _portTestsMonitorEnabled = _configuration.GetValue<bool>("PortTestsMonitor:Enabled", true);
+            _printerMonitorEnabled = _configuration.GetValue<bool>("PrinterMonitor:Enabled", true);
             _kioskUserEnabled = _configuration.GetValue<bool>("KioskUser:Enabled", true);
 
             // Local log settings
@@ -452,6 +467,98 @@ namespace EPNMonitoring
                 _logger.LogInformation("Device check summary: {Found} found, {Missing} missing, {Total} total.", foundCount, missingCount, _devicesToCheck.Count);
 
             // Flushing handled by TrackTelemetryEvent
+        }
+
+        /// <summary>
+        /// Checks printers matching the configured wildcard and ensures one is online.
+        /// Offline printers can optionally be removed and the online printer set as default.
+        /// </summary>
+        private void CheckPrintersAndSendTelemetry()
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(_printerNameWildcard))
+                {
+                    _logger.LogWarning("PrinterNameWildcard not configured.");
+                    return;
+                }
+                string query = $"SELECT * FROM Win32_Printer WHERE Name LIKE '{_printerNameWildcard.Replace("'", "''")}%'";
+                using var searcher = new ManagementObjectSearcher(query);
+                var printers = searcher.Get().Cast<ManagementObject>().ToList();
+
+                if (_verboseLoggingLocal)
+                    _logger.LogInformation("Printer check started. Wildcard: {Wildcard}, Found: {Count}", _printerNameWildcard, printers.Count);
+
+                ManagementObject? onlinePrinter = null;
+
+                foreach (var printer in printers)
+                {
+                    string name = printer["Name"]?.ToString() ?? string.Empty;
+                    bool workOffline = (bool)(printer["WorkOffline"] ?? false);
+                    int status = 0;
+                    try { status = Convert.ToInt32(printer["PrinterStatus"] ?? 0); } catch { }
+                    bool isOnline = !workOffline && status == 3; // 3 = Idle
+
+                    if (isOnline)
+                    {
+                        if (_verboseLoggingLocal)
+                            _logger.LogInformation("Printer online: {Name}", name);
+                        onlinePrinter = printer;
+                    }
+                    else
+                    {
+                        _logger.LogWarning("Printer offline or busy: {Name} (Status={Status}, WorkOffline={WorkOffline})", name, status, workOffline);
+                        TrackTelemetryEvent(
+                            "PrinterOffline",
+                            new Dictionary<string, string?>
+                            {
+                                ["PrinterName"] = name,
+                                ["Status"] = status.ToString(),
+                                ["WorkOffline"] = workOffline.ToString()
+                            },
+                            isInformational: false);
+
+                        if (_removeOfflinePrinters)
+                        {
+                            try
+                            {
+                                printer.Delete();
+                                _logger.LogInformation("Removed offline printer: {Name}", name);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex, "Failed to remove printer: {Name}", name);
+                            }
+                        }
+                    }
+                }
+
+                if (onlinePrinter == null)
+                {
+                    _logger.LogError("No online printers found for wildcard {Wildcard}", _printerNameWildcard);
+                    TrackTelemetryEvent(
+                        "PrinterOnlineNotFound",
+                        new Dictionary<string, string?> { ["Wildcard"] = _printerNameWildcard },
+                        isInformational: false);
+                }
+                else if (_setDefaultPrinter)
+                {
+                    try
+                    {
+                        onlinePrinter.InvokeMethod("SetDefaultPrinter", null);
+                        if (_verboseLoggingLocal)
+                            _logger.LogInformation("Set default printer to {Name}", onlinePrinter["Name"]);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Failed to set default printer: {Name}", onlinePrinter["Name"]);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Printer check failed.");
+            }
         }
 
         /// <summary>
@@ -850,6 +957,7 @@ namespace EPNMonitoring
             var websiteCheckTimer = _websiteCheckIntervalSeconds;
             var processCheckTimer = _checkIntervalSeconds;
             var deviceCheckTimer = _deviceCheckIntervalSeconds;
+            var printerCheckTimer = _printerCheckIntervalSeconds;
             var portTestsCheckTimer = _portTestsCheckIntervalSeconds;
             var eventViewerCheckTimer = _eventViewerCheckIntervalSeconds;
             var cleanLocalLogTimer = _localLogCheckIntervalSeconds;
@@ -886,6 +994,12 @@ namespace EPNMonitoring
                 {
                     CheckDevicesAndSendTelemetry();
                     deviceCheckTimer = _deviceCheckIntervalSeconds;
+                }
+
+                if (printerCheckTimer <= 0 && _printerMonitorEnabled)
+                {
+                    CheckPrintersAndSendTelemetry();
+                    printerCheckTimer = _printerCheckIntervalSeconds;
                 }
 
                 if (portTestsCheckTimer <= 0 && _portTestsMonitorEnabled)
@@ -925,6 +1039,7 @@ namespace EPNMonitoring
                 websiteCheckTimer--;
                 processCheckTimer--;
                 deviceCheckTimer--;
+                printerCheckTimer--;
                 portTestsCheckTimer--;
                 eventViewerCheckTimer--;
                 cleanLocalLogTimer--;

--- a/EPNMonitoring/appsettings.json
+++ b/EPNMonitoring/appsettings.json
@@ -77,6 +77,13 @@
     ],
     "CheckIntervalSeconds": 60
   },
+  "PrinterMonitor": {
+    "Enabled": true,
+    "PrinterNameWildcard": "Brother HL",
+    "CheckIntervalSeconds": 300,
+    "RemoveOfflinePrinters": false,
+    "SetAsDefaultPrinter": true
+  },
   "PortTestsMonitor": {
     "Enabled": true,
     "CheckIntervalSeconds": 300,

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ EPNMonitoring is a .NET 8 Worker Service designed for automated monitoring and t
 - **Device Monitoring:** Verifies presence of specified hardware devices at set intervals.
 - **Port Tests:** Tests connectivity to specified ports on configured servers.
 - **Kiosk User Monitoring:** Checks for the presence of configured kiosk user accounts.
-- **Default Printer Monitoring:** Ensures the default printer is set and can force the setting if required.
+ - **Printer Monitoring:** Verifies that a printer matching a configurable wildcard is online, can remove offline matches, and optionally sets it as the default printer.
 - **Verbose Logging:** Configurable logging to local file and Application Insights, with verbosity options for each.
 - **Local Log Management:** Maintains a local log file with autoclean and maximum size options.
 - **Update Log File:** Records Windows update logs to a specified file.
@@ -233,19 +233,21 @@ Below is a description of each configuration section and its parameters, based o
 
 ---
 
-### DefaultPrinter
+### PrinterMonitor
 ```json
-"DefaultPrinter": {
+"PrinterMonitor": {
   "Enabled": true,
-  "Name": "HP96",
-  "CheckIntervalSeconds": 60,
-  "ForceDefault": true
+  "PrinterNameWildcard": "Brother HL",
+  "CheckIntervalSeconds": 300,
+  "RemoveOfflinePrinters": false,
+  "SetAsDefaultPrinter": true
 }
 ```
-- **Enabled:** Enable/disable default printer monitoring.
-- **Name:** Name of the default printer.
-- **CheckIntervalSeconds:** How often to check the default printer.
-- **ForceDefault:** Force setting the default printer if needed.
+- **Enabled:** Enable/disable printer monitoring.
+- **PrinterNameWildcard:** Wildcard prefix used to identify the printer.
+- **CheckIntervalSeconds:** How often to check printer availability.
+- **RemoveOfflinePrinters:** Remove printers matching the wildcard that are offline.
+- **SetAsDefaultPrinter:** Set the online matching printer as the default.
 
 ---
 


### PR DESCRIPTION
## Summary
- monitor printers matching a configurable wildcard
- remove offline printer entries and optionally set default printer
- document printer monitoring settings

## Testing
- `dotnet build` *(fails: command not found)*
- `wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh` *(fails: Proxy tunneling failed: ForbiddenUnable to establish SSL connection)*

------
https://chatgpt.com/codex/tasks/task_e_68b0460e440083339aeabfc6e599c9d3